### PR TITLE
Update dependency compatibility information

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,11 +13,11 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-IterTools = "≥ 0.1.0"
-OrderedCollections = "≥ 1.0.0"
-ProgressMeter = "≥ 0.2.1"
-StaticArrays = "≥ 0.5.0"
-julia = "≥ 1.0.0"
+IterTools = "1"
+OrderedCollections = "1"
+ProgressMeter = "0.6, 0.7, 0.8, 0.9, 1"
+StaticArrays = "0.8, 0.9, 0.10, 0.11"
+julia = "1"
 
 [extras]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"


### PR DESCRIPTION
Use the lowest versions compatible with Julia 1.0 as lower bounds (as they are sufficient for ACME) and don't claim infinite upward compatibility, instead use the SemVer compatibility based on the latest released versions (with which ACME also does work).