### PR TITLE
Generalize ideal opamp to linear opamp

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ julia = "1"
 [extras]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 
 [targets]
-test = ["Test", "SparseArrays"]
+test = ["Test", "FFTW", "SparseArrays"]


### PR DESCRIPTION
Replace the ideal opamp model with a linear one (lowpass/integrator) where the ideal opamp is a special case.