### PR TITLE
Declare compatibility with StaticArrays v0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 IterTools = "1"
 OrderedCollections = "1"
 ProgressMeter = "0.6, 0.7, 0.8, 0.9, 1"
-StaticArrays = "0.8, 0.9, 0.10, 0.11"
+StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
Updating StaticArrays to 0.12 doesn't seem to cause any problems for ACME, so be a good citizen and don't prevent others from updating.