### PR TITLE
Fix a missing initialization with zeros in kd-tree lookup

### DIFF
--- a/src/kdtree.jl
+++ b/src/kdtree.jl
@@ -93,7 +93,7 @@ mutable struct Alts{T}
 end
 
 Alts(p::Vector{T}) where {T} =
-    Alts([AltEntry(1, Vector{T}(undef, length(p)), zero(T))], typemax(T), 0, 1)
+    Alts([AltEntry(1, zeros(T, length(p)), zero(T))], typemax(T), 0, 1)
 
 function init!(alts::Alts{T}, best_dist, best_pidx) where {T}
     alts.number_valid = 1


### PR DESCRIPTION
Since d8564311, inconsistencies between the stored delta vector and its norm will propagate, so they need to be initialized consistently.

Fixes #7.