### PR TITLE
Reflect that Julia 1.0 is the minimum required version in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Schematics"](http://www.eurasip.org/Proceedings/Eusipco/Eusipco2015/papers/15701
 ## Installation
 
 If you have not done so already, [download and install
-Julia](http://julialang.org/downloads/). (Any version starting with 0.6 should
+Julia](http://julialang.org/downloads/). (Any version starting with 1.0 should
 be fine; earlier ACME versions support Julia starting with version 0.3.)
 
 To install ACME, start Julia and run:

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -3,7 +3,7 @@
 ## Installation
 
 If you have not done so already, [download and install
-Julia](http://julialang.org/downloads/). (Any version starting with 0.6 should
+Julia](http://julialang.org/downloads/). (Any version starting with 1.0 should
 be fine; earlier ACME versions also support Julia 0.3 and later.)
 
 To install ACME, start Julia and run:


### PR DESCRIPTION
The README and the Getting started section still recommended at least version 0.6, but current ACME requires at least 1.0.