### PR TITLE
Use a Github action for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+    tags: '*'
+  pull_request:
+
+jobs:
+  test:
+    name: Test on Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ matrix.julia-arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: ['1.0', '1.1', '1.2', '1.3', 'nightly']
+        julia-arch: [x64, x86]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        exclude:
+          - os: macOS-latest
+            julia-arch: x86
+    steps:
+      - uses: actions/checkout@v1.0.0
+      - uses: julia-actions/setup-julia@v1.0.1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.julia-arch }}
+      - uses: julia-actions/julia-runtest@v0.1.0
+      - uses: julia-actions/julia-uploadcodecov@v0.1.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - uses: julia-actions/julia-uploadcoveralls@v0.1.0
+        env:
+          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}


### PR DESCRIPTION
~~Note: While the Travis configuration creates the documentation on all (supported) Julia version, this only does it with Julia 1.0.~~ EDIT: Documentation building moved to separate action (see #20).