### PR TITLE
Diasble `fail-fast` in documentation action

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -12,6 +12,7 @@ jobs:
     name: build on Julia ${{ matrix.julia-version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         julia-version: ['1.0', '1.1', '1.2', '1.3', 'nightly']
     steps:


### PR DESCRIPTION
If e.g. the docs build fails on nightly, the docs build on 1.0 (used to build the documentation that gets deployed) should still run to completion.