### PR TITLE
Fix docs build on Julia >=1.5

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -32,9 +32,9 @@ version = "0.8.1"
 
 [[Documenter]]
 deps = ["Base64", "Dates", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "885467cebde4639a3d81953652cc53ff5a73cb87"
+git-tree-sha1 = "395fa1554c69735802bba37d9e7d9586fd44326c"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.24.3"
+version = "0.24.11"
 
 [[InteractiveUtils]]
 deps = ["LinearAlgebra", "Markdown"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ ACME = "ca8b7239-ccd3-5cce-807f-2072f3f0d108"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "=0.24.3"
+Documenter = "=0.24.11"

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -257,7 +257,7 @@ end
 topomat(incidence::SparseMatrixCSC{<:Integer}) = topomat!(copy(incidence))
 topomat(c::Circuit) = topomat!(incidence(c))
 
-@doc doc"""
+@doc raw"""
     @circuit begin #= ... =# end
 
 Provides a simple domain-specific language to decribe circuits. The
@@ -318,8 +318,9 @@ If a net or pin specification is not just a single symbol or number, and has to
 be put in quotes (e.g. `"in+"`, `"9V"`)
 
 !!! note
-    Instead of `⟷` (`\\longleftrightarrow`), one can also use `==`.
-""" macro circuit(cdef)
+    Instead of `⟷` (`\longleftrightarrow`), one can also use `==`.
+"""
+macro circuit(cdef)
     is_conn_spec(expr::Expr) =
         (expr.head === :call && (expr.args[1] === :(⟷) || expr.args[1] === :(↔) || expr.args[1] === :(==))) ||
         (expr.head === :comparison && all(c -> c === :(==), expr.args[2:2:end]))
@@ -404,7 +405,7 @@ be put in quotes (e.g. `"in+"`, `"9V"`)
     return ccode
 end
 
-@doc doc"""
+@doc raw"""
     composite_element(circ; pinmap=Dict(), ports)
 
 Create a circuit element from the (sub-)circuit `circ`. The `pinmap` defines

--- a/src/elements.jl
+++ b/src/elements.jl
@@ -214,7 +214,7 @@ at `+`
 """
 currentprobe(;rs=0) = Element(mv=1, mi=-rs, pi=1, ports=[:+ => :-])
 
-@doc doc"""
+@doc raw"""
     diode(;is=1e-12, η = 1)
 
 Creates a diode obeying Shockley's law
@@ -234,7 +234,7 @@ Pins: `+` (anode) and `-` (cathode)
         end
   )
 
-@doc doc"""
+@doc raw"""
     bjt(typ; is=1e-12, η=1, isc=is, ise=is, ηc=η, ηe=η, βf=1000, βr=10,
         ile=0, ilc=0, ηcl=ηc, ηel=ηe, vaf=Inf, var=Inf, ikf=Inf, ikr=Inf)
 
@@ -393,7 +393,7 @@ Pins: `base`, `emitter`, `collector`
                    ports = [:base => :emitter, :base => :collector])
 end
 
-@doc doc"""
+@doc raw"""
     mosfet(typ; vt=0.7, α=2e-5, λ=0)
 
 Creates a MOSFET transistor with the simple model
@@ -465,7 +465,7 @@ Pins: `gate`, `source`, `drain`
     end
 end
 
-@doc doc"""
+@doc raw"""
     opamp(;maxgain=Inf, gain_bw_prod=Inf)
 
 Creates a linear operational amplifier as a voltage-controlled voltage source.
@@ -501,7 +501,7 @@ Pins: `in+` and `in-` for input, `out+` and `out-` for output
     end
 end
 
-@doc doc"""
+@doc raw"""
     opamp(Val{:macak}, gain, vomin, vomax)
 
 Creates a clipping operational amplifier where input and output voltage are


### PR DESCRIPTION
The used `@doc_str` caused Documenter to miss the contents when computing the line number range. On Julia 1.5 and later, that even caused the build to fail (by summing over an empty `Any[]`). Replacing with `@raw_str` fixes it. While at it, bump the Documenter version.