### PR TITLE
Tweaks to GHA workflows

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -6,6 +6,7 @@ on:
       - develop
     tags: '*'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - master
     tags: '*'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             julia-arch: x86
     steps:
       - uses: actions/checkout@v1.0.0
-      - uses: julia-actions/setup-julia@v1.1.4
+      - uses: julia-actions/setup-julia@v1.4.1
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,24 @@ jobs:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
       - uses: julia-actions/julia-runtest@v0.1.0
-      - uses: julia-actions/julia-uploadcodecov@v0.1.0
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      - uses: julia-actions/julia-uploadcoveralls@v0.1.0
-        env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info
+      - uses: coverallsapp/github-action@master
+        with:
+          path-to-lcov: lcov.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          flag-name: run-${{ matrix.os }}-${{ matrix.julia-version }}-${{ matrix.julia-arch }}
+          parallel: true
+
+  finish:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        parallel-finished: true

--- a/.github/workflows/compathelper.yml
+++ b/.github/workflows/compathelper.yml
@@ -16,4 +16,5 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/compathelper.yml
+++ b/.github/workflows/compathelper.yml
@@ -3,6 +3,7 @@ name: CompatHelper
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   CompatHelper:


### PR DESCRIPTION
* Bump version to 1.4.1 
* Set `COMPATHELPER_PRIV` (to `secrets.DOCUMENTER_KEY`) for CompatHelper action to enable PRs opened by it to trigger other actions, in particular CI.
* Allow manually triggering workflows by adding `workflow_dispatch:` to the `on:` block.