### PR TITLE
Fix clipping `opamp` nonlinear function

### DIFF
--- a/src/elements.jl
+++ b/src/elements.jl
@@ -527,6 +527,7 @@ Pins: `in+` and `in-` for input, `out+` and `out-` for output
             vi_scaled = vi * (gain/scale)
             res = @SVector [tanh(vi_scaled) * scale - vo]
             J = @SMatrix [gain / cosh(vi_scaled)^2 -1.0]
+            return (res, J)
         end
     return Element(mv=[0 0; 1 0; 0 1], mi=[1 0; 0 0; 0 0], mq=[0 0; -1 0; 0 -1],
                    u0=[0; 0; offset],

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -568,6 +568,17 @@ end
         Yref = [let ω=2*44100*tan(π*k/length(y)); 1/(G⁻¹(im*ω) + H(im*ω)); end for k in eachindex(Y).-1]
         @test Y ≈ Yref
     end
+
+    circ = @circuit begin
+        input = voltagesource(), [-] ⟷ gnd
+        op = opamp(Val{:macak}, 100, -3, 4), ["in+"] ⟷ input[+], ["in-"] ⟷ ["out-"] ⟷ gnd
+        output = voltageprobe(), [+] ⟷ op["out+"], [-] ⟷ gnd
+    end
+    u = range(-1, stop=1, length=1000)
+    model = DiscreteModel(circ, 1/44100)
+    y = run!(model, u')[1,:]
+    yref = [0.5*(4 + -3) + 0.5*(4 - -3)*tanh(100/(0.5*(4 - -3)) * u) for u in u]
+    @test y ≈ yref
 end
 
 function checksteady!(model)


### PR DESCRIPTION
Somehow this was missing the `return` which rendered it unusable...
Fixes #35.