### PR TITLE
Clean up `using` and `import` usage

### DIFF
--- a/src/ACME.jl
+++ b/src/ACME.jl
@@ -6,15 +6,15 @@ module ACME
 export DiscreteModel, run!, steadystate, steadystate!, linearize, ModelRunner
 
 using Compat: evalpoly
-using SparseArrays: SparseMatrixCSC, blockdiag, dropzeros!, findnz,
-    nonzeros, sparse, spzeros
+using IterTools: subsets
 using LinearAlgebra: BLAS, I, axpy!, lu, rmul!
 using Markdown: @doc_str
-
-using ProgressMeter
-using IterTools
 using OrderedCollections: OrderedDict
-using StaticArrays
+using ProgressMeter: @showprogress
+using SparseArrays: SparseMatrixCSC, blockdiag, dropzeros!, findnz,
+    nonzeros, sparse, spzeros
+using StaticArrays: @SMatrix, @SVector, SMatrix, SVector
+using Statistics: mean, var
 
 include("kdtree.jl")
 include("solvers.jl")

--- a/src/circuit.jl
+++ b/src/circuit.jl
@@ -3,8 +3,6 @@
 
 export Circuit, add!, connect!, disconnect!, @circuit, composite_element
 
-import Base: delete!
-
 struct CircuitNLFunc{Fs}
     fs::Fs
 end
@@ -130,7 +128,7 @@ end
 Deletes the element named `designator` from the circuit `c` (disconnecting all
 its pins).
 """
-function delete!(c::Circuit, designator::Symbol)
+function Base.delete!(c::Circuit, designator::Symbol)
     for net in c.nets
         filter!(elempin -> elempin[1] != designator, net)
     end

--- a/src/kdtree.jl
+++ b/src/kdtree.jl
@@ -1,10 +1,9 @@
-# Copyright 2016, 2017, 2018, 2019 Martin Holters
+# Copyright 2016, 2017, 2018, 2019, 2021 Martin Holters
 # See accompanying license file.
 
 import Base.deleteat!
 import Base.isless
 import Base.isempty
-using Statistics: mean, var
 
 mutable struct KDTree{Tcv<:AbstractVector,Tp<:AbstractMatrix}
     cut_dim::Vector{Int}

--- a/src/kdtree.jl
+++ b/src/kdtree.jl
@@ -1,10 +1,6 @@
 # Copyright 2016, 2017, 2018, 2019, 2021 Martin Holters
 # See accompanying license file.
 
-import Base.deleteat!
-import Base.isless
-import Base.isempty
-
 mutable struct KDTree{Tcv<:AbstractVector,Tp<:AbstractMatrix}
     cut_dim::Vector{Int}
     cut_val::Tcv
@@ -82,7 +78,7 @@ mutable struct AltEntry{T}
     delta_norm::T
 end
 
-isless(e1::AltEntry, e2::AltEntry) = isless(e1.delta_norm, e2.delta_norm)
+Base.isless(e1::AltEntry, e2::AltEntry) = isless(e1.delta_norm, e2.delta_norm)
 
 mutable struct Alts{T}
     entries::Vector{AltEntry{T}}
@@ -138,10 +134,10 @@ function siftdown!(alts::Alts, i)
     end
 end
 
-isempty(alts::Alts) = alts.number_valid == 0
+Base.isempty(alts::Alts) = alts.number_valid == 0
 peek(alts::Alts) = alts.entries[1]
 
-function deleteat!(alts::Alts, i::Integer)
+function Base.deleteat!(alts::Alts, i::Integer)
     alts.entries[i], alts.entries[alts.number_valid] = alts.entries[alts.number_valid], alts.entries[i]
     alts.number_valid -= 1
     if i ≤ alts.number_valid

--- a/src/solvers.jl
+++ b/src/solvers.jl
@@ -1,8 +1,7 @@
-# Copyright 2016, 2017, 2018, 2019 Martin Holters
+# Copyright 2016, 2017, 2018, 2019, 2021 Martin Holters
 # See accompanying license file.
 
 export SimpleSolver, HomotopySolver, CachingSolver
-import Base.copy!
 
 struct ParametricNonLinEq{F_eval<:Function,F_setp<:Function,F_calcjp<:Function,Scratch}
     func::F_eval
@@ -132,7 +131,7 @@ function solve!(solver::LinearSolver, x::Vector{Float64}, b::Vector{Float64})
     return nothing
 end
 
-function copy!(dest::LinearSolver, src::LinearSolver)
+function Base.copy!(dest::LinearSolver, src::LinearSolver)
     copyto!(dest.factors, src.factors)
     copyto!(dest.ipiv, src.ipiv)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,10 +5,10 @@ include("checklic.jl")
 
 using ACME
 using Compat: evalpoly, only
-using Test: @test, @test_broken, @test_logs, @test_throws, @testset
 using FFTW: rfft
-using ProgressMeter
+using ProgressMeter: Progress, next!
 using SparseArrays: sparse, spzeros
+using Test: @test, @test_broken, @test_logs, @test_throws, @testset
 
 @testset "topomat" begin
     tv, ti = ACME.topomat(sparse([1 -1 1; -1 1 -1]))


### PR DESCRIPTION
* Avoid `using Package` in favor of `using Package: func1, func2`
* Avoid `import Package: func1`, instead explicitly qualify `func1` where it is extended