### PR TITLE
Use `files` argument for codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1.2
       - uses: codecov/codecov-action@v3.1.1
         with:
-          file: lcov.info
+          files: lcov.info
       - uses: coverallsapp/github-action@master
         with:
           path-to-lcov: lcov.info


### PR DESCRIPTION
The argument used to be `file` for codecov-action@v1, but got renamed eventually.