### PR TITLE
Implement equality for `Element`

### DIFF
--- a/src/ACME.jl
+++ b/src/ACME.jl
@@ -1,4 +1,4 @@
-# Copyright 2015, 2016, 2017, 2018, 2019, 2020, 2021 Martin Holters
+# Copyright 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2023 Martin Holters
 # See accompanying license file.
 
 module ACME
@@ -96,6 +96,11 @@ struct Element
         )
     end
 end
+
+Base.:(==)(e1::Element, e2::Element) =
+    all(f -> (getfield(e1, f) == getfield(e2, f))::Bool, fieldnames(Element))
+Base.hash(e::Element, h::UInt) =
+    foldl((h, f) -> hash(getfield(e, f), h)::UInt, fieldnames(Element); init=h)
 
 for (n,m) in Dict(:nb => :mv, :nx => :mx, :nq => :mq, :nu => :mu)
   @eval ($n)(e::Element) = size(e.$m, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-# Copyright 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022 Martin Holters
+# Copyright 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 Martin Holters
 # See accompanying license file.
 
 include("checklic.jl")
@@ -38,6 +38,16 @@ end
     @test_throws DimensionMismatch ACME.solve!(solver, zeros(3), zeros(4))
     @test_throws DimensionMismatch ACME.solve!(solver, zeros(4), zeros(4))
     @test !ACME.setlhs!(solver, zeros(3,3))
+end
+
+@testset "Element equality" begin
+    @test resistor(1e3) == resistor(1e3)
+    @test hash(resistor(1e3)) == hash(resistor(1e3))
+    @test resistor(1e3) != resistor(2.2e3)
+    @test resistor(1) != voltagesource(1)
+    @test bjt(:npn) == bjt(:npn)
+    @test hash(bjt(:npn)) == hash(bjt(:npn))
+    @test bjt(:npn) != bjt(:pnp)
 end
 
 @testset "simple circuits" begin


### PR DESCRIPTION
This implements `==` (and consistent `hash`) for `Element`.

```julia
julia> resistor(1000) == resistor(1000)
false         # before
true          # this PR
```

It's still the case that `resistor(1000) !== resistor(1000)`, but that should be seen as an implementation detail that might change in the future.

To be consistent, it is now possibly to add the same `Element` instance for than once to the same `Circuit`:
```julia
julia> R = resistor(1000); circ = Circuit();

julia> add!(circ, R)
Symbol("##296")

julia> add!(circ, R)
Symbol("##296")    # before
Symbol("##297")    # this PR

julia> ACME.nb(circ)
1                  # before
2                  # this PR
```