### PR TITLE
Use kwarg interface of `ProgressMeter`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 IterTools = "1"
 OrderedCollections = "1"
-ProgressMeter = "0.6, 0.7, 0.8, 0.9, 1"
+ProgressMeter = "1.8"
 StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12, 1.0"
 julia = "1.4"
 

--- a/src/ACME.jl
+++ b/src/ACME.jl
@@ -650,7 +650,7 @@ is preserved accross calls to `run!`.
 function run!(runner::ModelRunner{<:DiscreteModel,true}, y::AbstractMatrix{Float64},
               u::AbstractMatrix{Float64})
     checkiosizes(runner, u, y)
-    @showprogress "Running model: " for n = 1:size(u, 2)
+    @showprogress desc="Running model: " for n = 1:size(u, 2)
         step!(runner, y, u, n)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -510,7 +510,7 @@ end
     end
     ηcl=1.2
     ηel=1.3
-    prog = Progress(2^9, "Testing Gummel-Poon model: ")
+    prog = Progress(2^9, desc="Testing Gummel-Poon model: ")
     @testset "Gummel-Poon $typ" for ile in (0, 50e-9), ilc in (0, 100e-9),
             ηcl in (ηc, 1.2), ηel in (ηe, 1.1),
             vaf in (Inf, 10), var in (Inf, 50),


### PR DESCRIPTION
This fixes deprecation warnings with ProgressMeter v1.9, but requires at least v1.8.